### PR TITLE
Tolerate no config

### DIFF
--- a/app/models/solidus_avatax_certified/avatax_log.rb
+++ b/app/models/solidus_avatax_certified/avatax_log.rb
@@ -18,7 +18,7 @@ module SolidusAvataxCertified
 
     def enabled?
       current_config = SolidusAvataxCertified::Current.config
-      current_config.log || current_config.log_to_stdout
+      current_config && (current_config.log || current_config.log_to_stdout)
     end
 
     def progname(progname = nil)

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ffaker'
   s.add_development_dependency "phantomjs", "~> 2.1.1"
   s.add_development_dependency "poltergeist", "~> 1.16"
+  s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rspec-rails", "~> 3.2"
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rubocop-rspec'
@@ -45,7 +46,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "selenium-webdriver", "~> 2.53.4"
   s.add_development_dependency 'shoulda-matchers', '~> 2.7'
   s.add_development_dependency "simplecov"
-  s.add_development_dependency "sqlite3", "~> 1.3.6"
+  s.add_development_dependency "sqlite3", "~> 1.3"
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'
 end

--- a/spec/models/solidus_avatax_certified/avatax_log_spec.rb
+++ b/spec/models/solidus_avatax_certified/avatax_log_spec.rb
@@ -11,10 +11,24 @@ describe SolidusAvataxCertified::AvataxLog, type: :model do
   end
 
   describe '#enabled?' do
-    it 'returns a boolean value' do
-      stub_avatax_preference(:log, true)
+    context 'when logging is enabled' do
+      before do
+        stub_avatax_preference(:log, true)
+      end
 
-      expect(logger).to be_enabled
+      it 'returns true' do
+        expect(logger).to be_enabled
+      end
+    end
+
+    context 'when no config is present' do
+      before do
+        allow(::SolidusAvataxCertified::Current).to receive(:config) { nil }
+      end
+
+      it 'returns false' do
+        expect(logger).to_not be_enabled
+      end
     end
   end
 


### PR DESCRIPTION
I observed that our recent review apps were hitting a "post-deploy exit code was not 0" error, and traced it to the `enabled?` method on the `AvataxLog` class. This improves the error catching on that method to return `false` if no avatax config is present.